### PR TITLE
Update image for NVIDIA GPU resource class

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 gpu: &gpu
   machine:
-    image: ubuntu-2004-cuda-11.4:202110-01
+    image: linux-cuda-11:2023.02.1 # ubuntu
   resource_class: gpu.nvidia.medium
 
 commands:


### PR DESCRIPTION
These old `ubuntu-*` images are [deprecated](https://discuss.circleci.com/t/linux-cuda-deprecation-and-image-policy/48568).